### PR TITLE
Fix 'Join Us' Button Functionality in Home Page Hero Section

### DIFF
--- a/src/components/Global/Hero.jsx
+++ b/src/components/Global/Hero.jsx
@@ -99,9 +99,11 @@ const GDSCLanding = () => {
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.8 }}
           >
+            <a href="/SignUp">
             <button className="px-8 py-3 bg-blue-500 text-white rounded-full hover:bg-blue-600 transition-colors">
               Join Us
             </button>
+            </a>
             <button className="px-8 py-3 border-2 border-blue-500 text-blue-500 rounded-full hover:bg-blue-50 transition-colors">
               Contact Us
             </button>


### PR DESCRIPTION
fixed  #351 
This update resolves the issue of the 'Join Us' button in the home page hero section, which was previously non-functional. The button has now been linked properly, ensuring it redirects users to the intended destination. This fix improves the user flow and interaction, encouraging engagement and creating a seamless navigation experience directly from the home page.

https://github.com/user-attachments/assets/ca14c117-4bb9-4444-a97d-4eef44d1defd



